### PR TITLE
feat: test result memory — don't re-test what already passed

### DIFF
--- a/scripts/qa/qa_final.py
+++ b/scripts/qa/qa_final.py
@@ -16,11 +16,13 @@ from loguru import logger
 from browser_use import Agent
 
 logger.remove()
-logger.add(sys.stderr, format="<green>{time:HH:mm:ss}</green> | <level>{level: <8}</level> | <cyan>{message}</cyan>", level="INFO")
-logger.add("scripts/qa_reports/qa_final_{time:YYYY-MM-DD}.log", rotation="10 MB", level="DEBUG")
+logger.add(
+	sys.stderr, format='<green>{time:HH:mm:ss}</green> | <level>{level: <8}</level> | <cyan>{message}</cyan>', level='INFO'
+)
+logger.add('scripts/qa_reports/qa_final_{time:YYYY-MM-DD}.log', rotation='10 MB', level='DEBUG')
 
 from shared import (
-	DEV_URL,
+	TestResultMemory,
 	cleanup_temp_profiles,
 	create_browser_session,
 	create_llm,
@@ -35,8 +37,32 @@ async def main():
 	llm = create_llm('sonnet')
 	session, tmp_dir = create_browser_session()
 
+	# Load test result memory
+	memory = TestResultMemory()
+	final_sections = [
+		'users',
+		'branding',
+		'help',
+		'sign_in',
+		'sign_up',
+		'preview_mode',
+		'preview_about',
+		'preview_how_it_works',
+		'preview_blogs',
+		'preview_blog_detail',
+		'dev_manual',
+		'lead_form',
+		'image_upload',
+		'blog_detail_lead_form',
+		'404_page',
+	]
+	memory.ensure_sections_tracked(final_sections)
+	memory_prompt = memory.prompt_section()
+
 	task = f"""You are doing the FINAL QA pass on https://dev.fairdealhousebuyer.com.
 You must test every item below. No exceptions. Auth: mark@localhousebuyers.net (already logged in via Chrome profile).
+
+{memory_prompt}
 
 ## CRITICAL: ALL URLs use https://dev.fairdealhousebuyer.com
 ## DO NOT visit /dev-admin — it is restricted.
@@ -200,6 +226,15 @@ At the end, include:
 	print('=' * 80)
 
 	save_report('qa_final', report)
+
+	# Update test result memory from the report
+	memory.update_from_report(report, final_sections)
+	memory.save()
+	logger.info(
+		f'Test memory updated: {len(memory.passed_sections())} passed, '
+		f'{len(memory.failed_sections())} failed, {len(memory.untested_sections())} untested'
+	)
+
 	shutil.rmtree(tmp_dir, ignore_errors=True)
 
 

--- a/scripts/qa/qa_full.py
+++ b/scripts/qa/qa_full.py
@@ -17,11 +17,13 @@ from browser_use import Agent
 
 # Configure loguru
 logger.remove()
-logger.add(sys.stderr, format="<green>{time:HH:mm:ss}</green> | <level>{level: <8}</level> | <cyan>{message}</cyan>", level="INFO")
-logger.add("qa_reports/qa_full_{time:YYYY-MM-DD}.log", rotation="10 MB", level="DEBUG")
+logger.add(
+	sys.stderr, format='<green>{time:HH:mm:ss}</green> | <level>{level: <8}</level> | <cyan>{message}</cyan>', level='INFO'
+)
+logger.add('qa_reports/qa_full_{time:YYYY-MM-DD}.log', rotation='10 MB', level='DEBUG')
 
 from shared import (
-	DEV_URL,
+	TestResultMemory,
 	cleanup_temp_profiles,
 	create_browser_session,
 	create_llm,
@@ -35,9 +37,9 @@ from shared import (
 async def fetch_sitemap_async() -> dict:
 	"""Fetch sitemap with fallback."""
 	from shared import fetch_sitemap
+
 	sitemap = await fetch_sitemap()
 	if not sitemap:
-		from shared import get_sitemap_or_fallback
 		logger.warning('Using hardcoded sitemap fallback')
 		return {
 			'public': [
@@ -52,9 +54,21 @@ async def fetch_sitemap_async() -> dict:
 			'admin': {
 				'path': '/admin',
 				'tabs': [
-					'Site Settings', 'Users', 'Leads', 'Blogs', 'Testimonials', 'Images',
-					'Find & Replace', 'Dev Manual', 'Webhook / CRM', 'AI Content',
-					'AI Settings', 'Business Info', 'Branding', 'Content', 'Email Settings',
+					'Site Settings',
+					'Users',
+					'Leads',
+					'Blogs',
+					'Testimonials',
+					'Images',
+					'Find & Replace',
+					'Dev Manual',
+					'Webhook / CRM',
+					'AI Content',
+					'AI Settings',
+					'Business Info',
+					'Branding',
+					'Content',
+					'Email Settings',
 				],
 			},
 			'restricted': ['/dev-admin'],
@@ -72,9 +86,31 @@ async def main():
 
 	# Build admin tabs list for targeted testing
 	admin_tabs = sitemap.get('admin', {}).get('tabs', [])
-	already_tested = ['Blogs', 'Site Settings', 'Business Info', 'Testimonials']
+	public_pages = [p['name'] for p in sitemap.get('public', [])]
 
-	untested_tabs = [t for t in admin_tabs if t not in already_tested]
+	# Load test result memory — tracks what's been tested across runs
+	memory = TestResultMemory()
+
+	# Ensure all known sections are tracked
+	all_sections = (
+		[t.lower().replace(' ', '_') for t in admin_tabs]
+		+ [p['name'].lower().replace(' ', '_') for p in sitemap.get('public', [])]
+		+ ['lead_form', 'preview_mode', 'image_upload']
+	)
+	memory.ensure_sections_tracked(all_sections)
+
+	# Determine what to test based on memory
+	untested = memory.untested_sections()
+	failed = memory.failed_sections()
+	passed = memory.passed_sections()
+
+	# Map section IDs back to admin tab names for untested tabs
+	admin_tab_ids = {t.lower().replace(' ', '_'): t for t in admin_tabs}
+	untested_tabs = [admin_tab_ids[sid] for sid in untested if sid in admin_tab_ids]
+	failed_tabs = [admin_tab_ids[sid] for sid in failed if sid in admin_tab_ids]
+
+	# Generate the memory-driven prompt section
+	memory_prompt = memory.prompt_section()
 
 	task = f"""You are an aggressive QA tester for Fair Deal House Buyer.
 Auth: mark@localhousebuyers.net (Google/Clerk — session already active).
@@ -90,54 +126,35 @@ Example: https://dev.fairdealhousebuyer.com/admin (NOT https://fairdealhousebuye
 ## Known Issues
 {issues}
 
-## ALREADY TESTED (DO NOT RE-TEST — skip these entirely):
-- ✅ Blog CRUD — full cycle works
-- ✅ Site Settings — toggles, data source, migrations work
-- ✅ Business Info — phone change/revert works, live site updates
-- ✅ Testimonials — create works, #84 confirmed, but DELETE not tested yet
-- ✅ Homepage — nav, hero, lead form submit works
-- ✅ /reviews — testimonials display, issues found
-- ✅ /about — FOUC found
-- ✅ /how-it-works — works
+{memory_prompt}
 
-## YOUR MISSION — Test ONLY what has NOT been tested:
+## YOUR MISSION — Focus on untested and failed sections:
 
 ### Priority 1: Untested Admin Tabs (click each one, interact with everything)
-{chr(10).join(f'- **{t}** — click it, report what loads, try every form/button' for t in untested_tabs)}
+{chr(10).join(f'- **{t}** — click it, report what loads, try every form/button' for t in untested_tabs) if untested_tabs else '- All admin tabs have been tested!'}
+
+{'### Priority 1b: Re-test Failed Admin Tabs' + chr(10) + chr(10).join(f'- **{t}** — previously failed, re-test now' for t in failed_tabs) if failed_tabs else ''}
 
 For EACH tab: click it, scroll through all content, try every button, fill every form, change a value, save, verify.
 
 ### Priority 2: Verify Lead in Admin
 - Go to admin Leads tab
-- Look for the E2E-TEST BrowserUse lead we submitted earlier
-- Can you see it? Delete it.
+- Look for any E2E-TEST BrowserUse leads
+- Can you see them? Delete them.
 
 ### Priority 3: Images — Upload + Edit Test
 - Go to Images tab
 - Try uploading a small test image
-- Try editing an existing image (Issue #85 — may throw server error)
+- Try editing an existing image
 - Report what happens
 
-### Priority 4: Testimonial Delete
-- Go to Testimonials tab
-- Find and DELETE the E2E-BROWSERUSE-TEST testimonial
-- Also delete any old E2E test testimonials
+### Priority 4: Public Pages Not Yet Tested
+- Test any public pages listed as NOT TESTED above
+- For each: does it load? What content appears?
 
-### Priority 5: Public Pages Not Yet Tested
-- /privacy — does it load? What content?
-- /terms — does it load? What content?
-- /help — does it load? What content?
-- /blogs — click into an individual blog post, does it render properly?
-
-### Priority 6: Preview Mode
+### Priority 5: Preview Mode
 - Go to /preview — does it load? What does it show?
-- Try clicking any pencil/edit icons (Issue #75, #83)
-
-### Priority 7: Branding
-- Go to admin Branding tab
-- What fields are there? (colors, logo, fonts?)
-- Change a color, save, check public site — did it update?
-- REVERT the color back
+- Try clicking any pencil/edit icons
 
 ## RULES
 - DO NOT visit /dev-admin
@@ -145,9 +162,16 @@ For EACH tab: click it, scroll through all content, try every button, fill every
 - Clean up test data (delete what you create)
 - Note any `data-source` attributes you see in the DOM
 - If you see [ACTION] logs in console, note them
+- SKIP sections marked as PASSED unless you have reason to believe they broke
 
 ## Report Format
-### ADMIN SECTIONS TESTED
+For EACH section you test, clearly state the section name and result:
+### SECTION: [section_name]
+**STATUS**: PASS / FAIL / PARTIAL
+**EVIDENCE**: [what you observed]
+**ISSUES**: [any issues found, or "none"]
+
+### SUMMARY
 ### WORKING
 ### BROKEN (with issue # if applicable)
 ### NEW ISSUES
@@ -188,6 +212,14 @@ For EACH tab: click it, scroll through all content, try every button, fill every
 	print('=' * 80)
 
 	save_report('qa_full', report)
+
+	# Update test result memory from the report
+	memory.update_from_report(report, all_sections)
+	memory.save()
+	logger.info(
+		f'Test memory updated: {len(memory.passed_sections())} passed, '
+		f'{len(memory.failed_sections())} failed, {len(memory.untested_sections())} untested'
+	)
 
 	# Cleanup
 	shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/scripts/qa/qa_verify.py
+++ b/scripts/qa/qa_verify.py
@@ -18,11 +18,13 @@ from loguru import logger
 from browser_use import Agent
 
 logger.remove()
-logger.add(sys.stderr, format="<green>{time:HH:mm:ss}</green> | <level>{level: <8}</level> | <cyan>{message}</cyan>", level="INFO")
-logger.add("scripts/qa_reports/qa_verify_{time:YYYY-MM-DD}.log", rotation="10 MB", level="DEBUG")
+logger.add(
+	sys.stderr, format='<green>{time:HH:mm:ss}</green> | <level>{level: <8}</level> | <cyan>{message}</cyan>', level='INFO'
+)
+logger.add('scripts/qa_reports/qa_verify_{time:YYYY-MM-DD}.log', rotation='10 MB', level='DEBUG')
 
 from shared import (
-	DEV_URL,
+	TestResultMemory,
 	cleanup_temp_profiles,
 	create_browser_session,
 	create_llm,
@@ -37,8 +39,28 @@ async def main():
 	llm = create_llm('sonnet')
 	session, tmp_dir = create_browser_session()
 
+	# Load test result memory to show the agent what's already been tested
+	memory = TestResultMemory()
+	memory_prompt = memory.prompt_section()
+
+	# Sections this script covers
+	verify_sections = [
+		'email_settings',
+		'branding',
+		'users',
+		'privacy',
+		'terms',
+		'blogs',
+		'preview_mode',
+		'lead_form',
+		'image_upload',
+	]
+	memory.ensure_sections_tracked(verify_sections)
+
 	task = f"""You are doing a FINAL VERIFICATION pass on dev.fairdealhousebuyer.com.
-Everything below has NEVER been tested. Test each item and report exactly what you see.
+Focus on items that have NOT been tested or previously FAILED.
+
+{memory_prompt}
 
 ## CRITICAL: ALL URLs use https://dev.fairdealhousebuyer.com
 
@@ -145,6 +167,15 @@ For each item, report:
 	print('=' * 80)
 
 	save_report('qa_verify', report)
+
+	# Update test result memory from the report
+	memory.update_from_report(report, verify_sections)
+	memory.save()
+	logger.info(
+		f'Test memory updated: {len(memory.passed_sections())} passed, '
+		f'{len(memory.failed_sections())} failed, {len(memory.untested_sections())} untested'
+	)
+
 	shutil.rmtree(tmp_dir, ignore_errors=True)
 
 

--- a/scripts/qa/shared.py
+++ b/scripts/qa/shared.py
@@ -12,7 +12,7 @@ import json
 import shutil
 import subprocess
 import tempfile
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import httpx
@@ -28,6 +28,205 @@ DEV_URL = 'https://dev.fairdealhousebuyer.com'
 REPORTS_DIR = Path(__file__).parent.parent / 'qa_reports'
 REPORTS_DIR.mkdir(exist_ok=True)
 
+# Test results persistence file
+TEST_RESULTS_FILE = REPORTS_DIR / 'test_results.json'
+
+
+class TestResultMemory:
+	"""Persistent test result tracking across QA runs.
+
+	Maintains a test_results.json that records which sections have been tested,
+	when, how many steps were used, and any issues found. On subsequent runs,
+	the agent prompt includes previous results so it can skip passing sections
+	and prioritize untested or failed areas.
+	"""
+
+	def __init__(self, results_path: Path = TEST_RESULTS_FILE):
+		self.results_path = results_path
+		self.data: dict = self._load()
+
+	def _load(self) -> dict:
+		"""Load existing results or initialize empty state."""
+		if self.results_path.exists():
+			try:
+				data = json.loads(self.results_path.read_text())
+				logger.info(f'Loaded test results: {len(data.get("sections", {}))} sections tracked')
+				return data
+			except (json.JSONDecodeError, KeyError) as e:
+				logger.warning(f'Corrupt test_results.json, starting fresh: {e}')
+		return {'last_run': None, 'sections': {}}
+
+	def save(self) -> None:
+		"""Persist current results to disk."""
+		self.data['last_run'] = datetime.now(timezone.utc).isoformat()
+		self.results_path.write_text(json.dumps(self.data, indent=2, default=str))
+		logger.success(f'Saved test results to {self.results_path}')
+
+	def get_section(self, section_id: str) -> dict:
+		"""Get a section's test result, or a default 'not_tested' entry."""
+		return self.data.setdefault('sections', {}).get(
+			section_id,
+			{
+				'status': 'not_tested',
+				'tested_at': None,
+				'steps_used': 0,
+				'issues_found': [],
+			},
+		)
+
+	def mark_tested(
+		self,
+		section_id: str,
+		status: str = 'pass',
+		steps_used: int = 0,
+		issues_found: list[str] | None = None,
+	) -> None:
+		"""Record a section as tested with its result."""
+		assert status in ('pass', 'fail', 'partial', 'not_tested'), f'Invalid status: {status}'
+		self.data.setdefault('sections', {})[section_id] = {
+			'status': status,
+			'tested_at': datetime.now(timezone.utc).isoformat(),
+			'steps_used': steps_used,
+			'issues_found': issues_found or [],
+		}
+
+	def invalidate(self, section_id: str) -> None:
+		"""Mark a section as needing re-test (e.g., code changed)."""
+		sections = self.data.get('sections', {})
+		if section_id in sections:
+			sections[section_id]['status'] = 'not_tested'
+			sections[section_id]['tested_at'] = None
+			logger.info(f'Invalidated section: {section_id}')
+
+	def invalidate_all(self) -> None:
+		"""Reset all sections to not_tested."""
+		for section_id in self.data.get('sections', {}):
+			self.invalidate(section_id)
+		logger.info('Invalidated all sections')
+
+	def sections_by_status(self, status: str) -> list[str]:
+		"""Get all section IDs with a given status."""
+		return [sid for sid, info in self.data.get('sections', {}).items() if info.get('status') == status]
+
+	def untested_sections(self) -> list[str]:
+		"""Get sections that have never been tested or were invalidated."""
+		return self.sections_by_status('not_tested')
+
+	def passed_sections(self) -> list[str]:
+		"""Get sections that passed."""
+		return self.sections_by_status('pass')
+
+	def failed_sections(self) -> list[str]:
+		"""Get sections that failed or had issues."""
+		return self.sections_by_status('fail') + self.sections_by_status('partial')
+
+	def ensure_sections_tracked(self, section_ids: list[str]) -> None:
+		"""Register sections that should be tracked, without overwriting existing results."""
+		sections = self.data.setdefault('sections', {})
+		for sid in section_ids:
+			if sid not in sections:
+				sections[sid] = {
+					'status': 'not_tested',
+					'tested_at': None,
+					'steps_used': 0,
+					'issues_found': [],
+				}
+
+	def prompt_section(self) -> str:
+		"""Generate a prompt section summarizing previous test results.
+
+		This is injected into the agent task so it knows what to skip and what to prioritize.
+		"""
+		sections = self.data.get('sections', {})
+		if not sections:
+			return '## Previous Test Results\nNo previous test results — test everything.'
+
+		lines = ['## Previous Test Results (skip PASSED sections unless code changed):']
+
+		# Group by status for clear prioritization
+		for sid, info in sorted(sections.items(), key=lambda x: _status_sort_key(x[1].get('status', 'not_tested'))):
+			status = info.get('status', 'not_tested')
+			tested_at = info.get('tested_at')
+			steps = info.get('steps_used', 0)
+			issues = info.get('issues_found', [])
+
+			if status == 'pass':
+				icon = '✅'
+				detail = f'PASSED {tested_at or "unknown"} ({steps} steps)'
+				if issues:
+					detail += f' — found issues: {", ".join(issues)}'
+			elif status == 'fail':
+				icon = '❌'
+				detail = f'FAILED {tested_at or "unknown"}'
+				if issues:
+					detail += f' — issues: {", ".join(issues)}'
+				detail += ' — RE-TEST THIS'
+			elif status == 'partial':
+				icon = '⚠️'
+				detail = f'PARTIAL {tested_at or "unknown"}'
+				if issues:
+					detail += f' — issues: {", ".join(issues)}'
+				detail += ' — NEEDS MORE TESTING'
+			else:
+				icon = '🔲'
+				detail = 'NOT TESTED — test this'
+
+			lines.append(f'- {icon} **{sid}**: {detail}')
+
+		# Add priority guidance
+		untested = self.untested_sections()
+		failed = self.failed_sections()
+		if untested:
+			lines.append(f'\n**PRIORITY: Test these first:** {", ".join(untested)}')
+		if failed:
+			lines.append(f'**RE-TEST these (previously failed):** {", ".join(failed)}')
+
+		passed = self.passed_sections()
+		if passed:
+			lines.append(f'**SKIP these (already passed):** {", ".join(passed)}')
+
+		return '\n'.join(lines)
+
+	def update_from_report(self, report_text: str, all_section_ids: list[str]) -> None:
+		"""Parse a QA report and update section results based on keywords.
+
+		Scans the report for section names and PASS/FAIL/BROKEN keywords to auto-update
+		results. This is a best-effort heuristic — manual mark_tested() calls are more precise.
+		"""
+		report_upper = report_text.upper()
+
+		for sid in all_section_ids:
+			# Normalize section id to searchable form
+			search_term = sid.replace('_', ' ').upper()
+
+			if search_term not in report_upper:
+				continue
+
+			# Find the context: from the section mention to the next section header or 150 chars
+			idx = report_upper.index(search_term)
+			end = len(report_upper)
+			# Look for next "### " section header after this one
+			next_section = report_upper.find('\n###', idx + len(search_term))
+			if next_section != -1:
+				end = next_section
+			context = report_upper[idx : min(end, idx + 150)]
+
+			if 'PASS' in context and 'FAIL' not in context:
+				self.mark_tested(sid, status='pass')
+			elif 'FAIL' in context or 'BROKEN' in context or 'ERROR' in context:
+				# Extract issues if possible
+				issues = []
+				if 'ISSUE' in context or 'BUG' in context:
+					issues.append('see report for details')
+				self.mark_tested(sid, status='fail', issues_found=issues)
+			elif 'PARTIAL' in context or 'INCONCLUSIVE' in context:
+				self.mark_tested(sid, status='partial')
+
+
+def _status_sort_key(status: str) -> int:
+	"""Sort sections: not_tested first, then fail, partial, pass last."""
+	return {'not_tested': 0, 'fail': 1, 'partial': 2, 'pass': 3}.get(status, 0)
+
 
 async def fetch_sitemap() -> dict | None:
 	"""Fetch the dev sitemap from /api/dev/sitemap. Returns None if not available."""
@@ -36,7 +235,9 @@ async def fetch_sitemap() -> dict | None:
 			resp = await client.get(f'{DEV_URL}/api/dev/sitemap')
 			if resp.status_code == 200:
 				data = resp.json()
-				logger.success(f"Fetched sitemap: {len(data.get('public', []))} public, {len(data.get('admin', {}).get('tabs', []))} admin tabs")
+				logger.success(
+					f'Fetched sitemap: {len(data.get("public", []))} public, {len(data.get("admin", {}).get("tabs", []))} admin tabs'
+				)
 				return data
 			else:
 				logger.warning(f'Sitemap returned {resp.status_code} — using hardcoded fallback')
@@ -67,9 +268,21 @@ def get_sitemap_or_fallback() -> dict:
 		'admin': {
 			'path': '/admin',
 			'tabs': [
-				'Site Settings', 'Users', 'Leads', 'Blogs', 'Testimonials', 'Images',
-				'Find & Replace', 'Dev Manual', 'Webhook / CRM', 'AI Content',
-				'AI Settings', 'Business Info', 'Branding', 'Content', 'Email Settings',
+				'Site Settings',
+				'Users',
+				'Leads',
+				'Blogs',
+				'Testimonials',
+				'Images',
+				'Find & Replace',
+				'Dev Manual',
+				'Webhook / CRM',
+				'AI Content',
+				'AI Settings',
+				'Business Info',
+				'Branding',
+				'Content',
+				'Email Settings',
 			],
 		},
 		'restricted': ['/dev-admin'],
@@ -94,8 +307,8 @@ def get_github_issues(repo: str = 'Mark0025/wes') -> str:
 	issues = json.loads(result.stdout)
 	lines = []
 	for issue in issues:
-		labels = ', '.join(l['name'] for l in issue.get('labels', []))
-		lines.append(f"- #{issue['number']}: {issue['title']} [{labels}]")
+		labels = ', '.join(label['name'] for label in issue.get('labels', []))
+		lines.append(f'- #{issue["number"]}: {issue["title"]} [{labels}]')
 	logger.success(f'Fetched {len(lines)} open issues')
 	return '\n'.join(lines)
 
@@ -141,7 +354,7 @@ def sitemap_prompt_section(sitemap: dict) -> str:
 	lines.append('')
 	lines.append('### Public Pages')
 	for page in sitemap.get('public', []):
-		lines.append(f"- `{DEV_URL}{page['path']}` — {page['name']}")
+		lines.append(f'- `{DEV_URL}{page["path"]}` — {page["name"]}')
 	lines.append('')
 	lines.append(f'### Admin Dashboard ({DEV_URL}/admin)')
 	lines.append('Tabs in sidebar: ' + ', '.join(sitemap.get('admin', {}).get('tabs', [])))
@@ -198,7 +411,7 @@ def create_test_image(path: str = '/tmp/browser-use-test-image.png') -> str:
 
 	def chunk(chunk_type: bytes, data: bytes) -> bytes:
 		c = chunk_type + data
-		crc = struct.pack('>I', _zlib.crc32(c) & 0xffffffff)
+		crc = struct.pack('>I', _zlib.crc32(c) & 0xFFFFFFFF)
 		return struct.pack('>I', len(data)) + c + crc
 
 	png = b'\x89PNG\r\n\x1a\n'
@@ -214,6 +427,7 @@ def create_test_image(path: str = '/tmp/browser-use-test-image.png') -> str:
 def cleanup_temp_profiles():
 	"""Remove all temporary Chrome profiles."""
 	import glob
+
 	for d in glob.glob('/tmp/browser-use-chrome-*'):
 		shutil.rmtree(d, ignore_errors=True)
 	logger.info('Cleaned up temp Chrome profiles')


### PR DESCRIPTION
## Summary
- Adds `TestResultMemory` class to `scripts/qa/shared.py` that persists test results to `test_results.json` across QA runs
- Replaces the hardcoded `already_tested` list in `qa_full.py` with memory-driven section tracking
- All 3 QA scripts (`qa_full`, `qa_verify`, `qa_final`) now load previous results, inject them into agent prompts, and save updated results after each run

## How it works
- `TestResultMemory` tracks each section's status (`pass`/`fail`/`partial`/`not_tested`), timestamp, steps used, and issues found
- On each run, a `## Previous Test Results` prompt section is generated telling the agent which sections to skip (passed) and which to prioritize (untested/failed)
- After the run, `update_from_report()` parses the agent's report text to auto-detect PASS/FAIL/PARTIAL per section
- Supports `invalidate()` and `invalidate_all()` for when code changes require re-testing

## Test plan
- [x] Unit tested `TestResultMemory` class (load, save, mark_tested, invalidate, prompt_section, update_from_report)
- [x] Verified report parsing correctly scopes context per section (no cross-section bleed)
- [x] `ruff check` and `ruff format` pass on all changed files
- [x] No new dependencies added

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# PR Summary: Test Result Memory — Persistent QA Test Tracking

## Overview
Introduces a `TestResultMemory` class to persist QA test results across runs, allowing the agent to skip previously-passed sections and prioritize untested/failed areas. Integrates the system into all three QA scripts (qa_full, qa_verify, qa_final).

## Key Changes

**New Component: `TestResultMemory` class** (scripts/qa/shared.py)
- Loads/saves `test_results.json` with per-section tracking: status (pass/fail/partial/not_tested), timestamp, steps used, and issues
- Provides section filtering methods: `untested_sections()`, `passed_sections()`, `failed_sections()`
- Generates human-readable prompts via `prompt_section()` that are injected into agent tasks
- Heuristic report parsing via `update_from_report()` to auto-detect section outcomes from agent reports
- Invalidation support via `invalidate()` and `invalidate_all()` methods

**Integration into QA Scripts**
- All three scripts (qa_full, qa_verify, qa_final) now instantiate `TestResultMemory`
- Inject `memory_prompt` into task instructions before execution
- Call `memory.update_from_report()` and `memory.save()` after generating reports
- Log summary counts of passed/failed/untested sections

## Identified Issues & Quality Concerns

**Critical: Path Inconsistency Bug**
- `qa_full.py` logs to `qa_reports/qa_full_{time}.log` (missing `scripts/` prefix)
- `qa_verify.py` and `qa_final.py` correctly use `scripts/qa_reports/`
- Actual path structure is `scripts/qa_reports/` — qa_full.py logs will fail or log to wrong location

**Type Safety & Best Practices**
- Uses plain `dict` for data structure instead of `TypedDict` or `@dataclass` — reduces IDE autocomplete and type checking
- `json.dumps(..., default=str)` masks serialization issues (converts unserializable objects to strings silently)
- Should validate data structure before save to catch corruption early

**Report Parsing Fragility**
- `update_from_report()` uses heuristic pattern matching (150-char context window) rather than structured parsing
- Prone to false positives/negatives (e.g., "FAIL" in unrelated context, truncated section boundaries)
- No handling for concurrent file access — could corrupt data if runs overlap

**Missing Test Coverage**
- PR objectives claim "Unit tests for TestResultMemory...present and checked" but no test files found in codebase
- No pytest fixtures or integration tests for the memory system
- Reliability claims unvalidated

**Error Handling Gaps**
- `save()` has no error handling — silent failure if disk is full, permissions denied, or JSON serialization fails
- No atomic writes or backup mechanism for test_results.json
- `_load()` catches JSON corruption but doesn't validate schema

## Code Quality Observations

**Strengths:**
- Uses `timezone.utc` for timestamps (good practice)
- Proper logging with appropriate levels
- Status validation via assertion in `mark_tested()`
- Clear docstrings

**Minor Issues:**
- Quote style inconsistencies between files (single quotes in shared.py, mixed elsewhere)
- Logging path bugs suggest incomplete testing across all scripts
- No configuration for custom results file location (hardcoded path only)

## Alignment with Best Practices

**Does NOT fully align with senior-level standards:**
- Skips formal type definitions in favor of plain dicts
- Heuristic parsing is fragile; structured output would be better
- Missing comprehensive test coverage before merge
- Path inconsistencies suggest insufficient testing across all modified files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->