### PR TITLE
feat: network interception — see API calls and server responses

### DIFF
--- a/browser_use/browser/watchdogs/network_watchdog.py
+++ b/browser_use/browser/watchdogs/network_watchdog.py
@@ -1,0 +1,316 @@
+"""Network Interception Watchdog for Browser-Use sessions.
+
+Captures API/XHR network activity via CDP Network domain and exposes
+a rolling log of recent requests with URL, method, status, and selected
+response headers. Designed for QA and debugging — the agent can see
+which API calls the frontend makes and what comes back.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import deque
+from typing import Any, ClassVar
+
+from bubus import BaseEvent
+from cdp_use.cdp.network.events import (
+	LoadingFailedEvent,
+	RequestWillBeSentEvent,
+	ResponseReceivedEvent,
+)
+from pydantic import ConfigDict, Field, PrivateAttr
+
+from browser_use.browser.events import BrowserConnectedEvent, TabCreatedEvent
+from browser_use.browser.watchdog_base import BaseWatchdog
+
+
+class NetworkEntry:
+	"""A single captured network request/response pair."""
+
+	__slots__ = (
+		'request_id',
+		'url',
+		'method',
+		'status',
+		'status_text',
+		'response_headers',
+		'resource_type',
+		'failed',
+		'error_text',
+		'timestamp',
+	)
+
+	def __init__(
+		self,
+		request_id: str,
+		url: str,
+		method: str,
+		resource_type: str | None = None,
+	) -> None:
+		self.request_id = request_id
+		self.url = url
+		self.method = method
+		self.status: int | None = None
+		self.status_text: str | None = None
+		self.response_headers: dict[str, str] = {}
+		self.resource_type = resource_type
+		self.failed = False
+		self.error_text: str | None = None
+		self.timestamp = time.time()
+
+	def format_short(self) -> str:
+		"""One-line summary for agent context injection."""
+		status_str = str(self.status) if self.status is not None else 'PENDING'
+		if self.failed:
+			status_str = f'FAILED({self.error_text or "unknown"})'
+
+		# Extract interesting headers
+		header_parts: list[str] = []
+		for key in ('x-data-source', 'x-cache', 'content-type'):
+			val = self.response_headers.get(key)
+			if val:
+				header_parts.append(f'{key}: {val}')
+
+		header_str = f' ({", ".join(header_parts)})' if header_parts else ''
+
+		# Shorten URL to path only for readability
+		path = self.url
+		try:
+			from urllib.parse import urlparse
+
+			parsed = urlparse(self.url)
+			path = parsed.path
+			if parsed.query:
+				path += f'?{parsed.query[:50]}'
+		except Exception:
+			pass
+
+		return f'- {self.method} {path} → {status_str}{header_str}'
+
+
+# Default URL patterns that indicate API/action calls worth capturing
+DEFAULT_API_PATTERNS: list[str] = [
+	'/api/',
+	'/actions',
+	'action=',
+	'/graphql',
+	'/trpc/',
+	'/_next/data/',
+]
+
+# Resource types to always skip (static assets)
+SKIP_RESOURCE_TYPES: set[str] = {
+	'Stylesheet',
+	'Image',
+	'Media',
+	'Font',
+	'Manifest',
+	'Preflight',
+}
+
+
+def _is_api_request(url: str, resource_type: str | None, api_patterns: list[str]) -> bool:
+	"""Check if a request looks like an API call rather than a static asset fetch."""
+	if resource_type and resource_type in SKIP_RESOURCE_TYPES:
+		return False
+
+	# XHR and Fetch are almost always API calls
+	if resource_type in ('XHR', 'Fetch'):
+		return True
+
+	# Check URL patterns
+	url_lower = url.lower()
+	return any(pattern in url_lower for pattern in api_patterns)
+
+
+class NetworkWatchdog(BaseWatchdog):
+	"""Captures API network activity via CDP and exposes a rolling log.
+
+	Attach to a BrowserSession to start capturing. Access the log via
+	``get_network_log()`` or ``format_for_prompt()``.
+
+	Unlike HarRecordingWatchdog, this watchdog:
+	- Only captures API/XHR calls (not all HTTPS traffic)
+	- Keeps a bounded in-memory log (no disk writes)
+	- Provides real-time access to the log for agent context injection
+	"""
+
+	model_config = ConfigDict(
+		arbitrary_types_allowed=True,
+		extra='forbid',
+		validate_assignment=False,
+		revalidate_instances='never',
+	)
+
+	LISTENS_TO: ClassVar[list[type[BaseEvent]]] = [BrowserConnectedEvent, TabCreatedEvent]
+	EMITS: ClassVar[list[type[BaseEvent]]] = []
+
+	max_entries: int = Field(default=100, description='Maximum number of entries to keep in the rolling log')
+	api_patterns: list[str] = Field(
+		default_factory=lambda: list(DEFAULT_API_PATTERNS),
+		description='URL patterns that identify API calls worth capturing',
+	)
+
+	_entries: dict[str, NetworkEntry] = PrivateAttr(default_factory=dict)
+	_log: deque[NetworkEntry] = PrivateAttr(default_factory=lambda: deque(maxlen=100))
+	_enabled: bool = PrivateAttr(default=False)
+	_enabled_sessions: set[str] = PrivateAttr(default_factory=set)
+
+	def __init__(self, **kwargs: Any) -> None:
+		super().__init__(**kwargs)
+		self._log = deque(maxlen=self.max_entries)
+
+	async def on_BrowserConnectedEvent(self, event: BrowserConnectedEvent) -> None:
+		"""Enable Network domain on the root CDP session."""
+		try:
+			cdp_session = await self.browser_session.get_or_create_cdp_session()
+			session_id = cdp_session.session_id
+
+			if session_id in self._enabled_sessions:
+				return
+
+			await cdp_session.cdp_client.send.Network.enable(session_id=session_id)
+
+			cdp = self.browser_session.cdp_client.register
+			cdp.Network.requestWillBeSent(self._on_request_will_be_sent)
+			cdp.Network.responseReceived(self._on_response_received)
+			cdp.Network.loadingFailed(self._on_loading_failed)
+
+			self._enabled_sessions.add(session_id)
+			self._enabled = True
+			self.logger.info('🌐 Network interception enabled — capturing API calls')
+		except Exception as e:
+			self.logger.warning(f'Failed to enable network interception: {e}')
+
+	async def on_TabCreatedEvent(self, event: TabCreatedEvent) -> None:
+		"""Enable Network domain on new tab sessions."""
+		if not self._enabled:
+			return
+		try:
+			cdp_session = await self.browser_session.get_or_create_cdp_session(target_id=event.target_id)
+			session_id = cdp_session.session_id
+			if session_id not in self._enabled_sessions:
+				await cdp_session.cdp_client.send.Network.enable(session_id=session_id)
+				self._enabled_sessions.add(session_id)
+		except Exception as e:
+			self.logger.debug(f'Network enable on new tab failed (non-fatal): {e}')
+
+	# ============ CDP Event Handlers (sync) ============
+
+	def _on_request_will_be_sent(self, params: RequestWillBeSentEvent, session_id: str | None) -> None:
+		try:
+			req = params.get('request', {}) if hasattr(params, 'get') else getattr(params, 'request', {})
+			url = req.get('url') if isinstance(req, dict) else getattr(req, 'url', None)
+			if not url:
+				return
+
+			request_id = params.get('requestId') if hasattr(params, 'get') else getattr(params, 'requestId', None)
+			if not request_id:
+				return
+
+			resource_type = params.get('type') if hasattr(params, 'get') else getattr(params, 'type', None)
+			method = (req.get('method') if isinstance(req, dict) else getattr(req, 'method', None)) or 'GET'
+
+			if not _is_api_request(url, resource_type, self.api_patterns):
+				return
+
+			entry = NetworkEntry(
+				request_id=request_id,
+				url=url,
+				method=method,
+				resource_type=resource_type,
+			)
+			self._entries[request_id] = entry
+			self._log.append(entry)
+		except Exception:
+			pass
+
+	def _on_response_received(self, params: ResponseReceivedEvent, session_id: str | None) -> None:
+		try:
+			request_id = params.get('requestId') if hasattr(params, 'get') else getattr(params, 'requestId', None)
+			if not request_id or request_id not in self._entries:
+				return
+
+			response = params.get('response', {}) if hasattr(params, 'get') else getattr(params, 'response', {})
+			entry = self._entries[request_id]
+			entry.status = response.get('status') if isinstance(response, dict) else getattr(response, 'status', None)
+			entry.status_text = (
+				response.get('statusText') if isinstance(response, dict) else getattr(response, 'statusText', None)
+			)
+
+			headers_raw = response.get('headers') if isinstance(response, dict) else getattr(response, 'headers', None)
+			if headers_raw is None:
+				entry.response_headers = {}
+			elif isinstance(headers_raw, dict):
+				entry.response_headers = {k.lower(): str(v) for k, v in headers_raw.items()}
+			elif isinstance(headers_raw, list):
+				entry.response_headers = {
+					h.get('name', '').lower(): str(h.get('value') or '') for h in headers_raw if isinstance(h, dict)
+				}
+			else:
+				try:
+					headers_dict = dict(headers_raw) if hasattr(headers_raw, '__iter__') else {}
+					entry.response_headers = {k.lower(): str(v) for k, v in headers_dict.items()}
+				except Exception:
+					entry.response_headers = {}
+
+			# Log errors prominently
+			if entry.status and entry.status >= 400:
+				self.logger.debug(f'🌐 API error: {entry.method} {entry.url} → {entry.status}')
+		except Exception:
+			pass
+
+	def _on_loading_failed(self, params: LoadingFailedEvent, session_id: str | None) -> None:
+		try:
+			request_id = params.get('requestId') if hasattr(params, 'get') else getattr(params, 'requestId', None)
+			if not request_id or request_id not in self._entries:
+				return
+			entry = self._entries[request_id]
+			entry.failed = True
+			entry.error_text = params.get('errorText') if hasattr(params, 'get') else getattr(params, 'errorText', None)
+			self.logger.debug(f'🌐 API failed: {entry.method} {entry.url} — {entry.error_text}')
+		except Exception:
+			pass
+
+	# ============ Public API ============
+
+	def get_entries(self, last_n: int | None = None) -> list[NetworkEntry]:
+		"""Get captured network entries, optionally limited to the last N."""
+		entries = list(self._log)
+		if last_n is not None:
+			entries = entries[-last_n:]
+		return entries
+
+	def get_error_entries(self) -> list[NetworkEntry]:
+		"""Get only entries with 4xx/5xx status or failures."""
+		return [e for e in self._log if e.failed or (e.status is not None and e.status >= 400)]
+
+	def format_for_prompt(self, last_n: int = 15) -> str:
+		"""Format recent network activity as a prompt section for agent context.
+
+		Returns a markdown section showing recent API calls with status codes
+		and key response headers. Highlights errors.
+		"""
+		entries = self.get_entries(last_n=last_n)
+		if not entries:
+			return ''
+
+		lines = [f'## Network Activity (last {len(entries)} API calls)']
+		for entry in entries:
+			line = entry.format_short()
+			# Highlight errors
+			if entry.failed or (entry.status is not None and entry.status >= 400):
+				line += ' ← ERROR'
+			lines.append(line)
+
+		# Summary of errors
+		errors = self.get_error_entries()
+		if errors:
+			lines.append(f'\n⚠️ {len(errors)} API error(s) detected — investigate these!')
+
+		return '\n'.join(lines)
+
+	def clear(self) -> None:
+		"""Clear all captured entries."""
+		self._entries.clear()
+		self._log.clear()

--- a/scripts/qa/network_interception.py
+++ b/scripts/qa/network_interception.py
@@ -1,0 +1,63 @@
+"""
+Network interception utilities for QA scripts.
+
+Provides helpers to attach network monitoring to a BrowserSession
+and inject captured API activity into the agent's context.
+
+Usage:
+    from network_interception import attach_network_watchdog, network_prompt_section
+
+    session, tmp_dir = create_browser_session()
+    watchdog = attach_network_watchdog(session)
+
+    # Later, get a prompt section for agent context:
+    network_section = network_prompt_section(watchdog, last_n=15)
+"""
+
+from __future__ import annotations
+
+from browser_use import BrowserSession
+from browser_use.browser.watchdogs.network_watchdog import NetworkWatchdog
+
+
+def attach_network_watchdog(
+	session: BrowserSession,
+	max_entries: int = 100,
+	api_patterns: list[str] | None = None,
+) -> NetworkWatchdog:
+	"""Attach a NetworkWatchdog to a BrowserSession.
+
+	Call this BEFORE the session connects to the browser. The watchdog
+	will automatically start capturing API calls once the browser connects.
+
+	Args:
+		session: The BrowserSession to monitor.
+		max_entries: Maximum number of entries to keep in the rolling log.
+		api_patterns: Custom URL patterns to identify API calls.
+			Defaults to common patterns like '/api/', '/actions', etc.
+
+	Returns:
+		The attached NetworkWatchdog instance. Use its ``format_for_prompt()``
+		method to get a formatted string for agent context injection.
+	"""
+	NetworkWatchdog.model_rebuild()
+
+	kwargs: dict = {
+		'event_bus': session.event_bus,
+		'browser_session': session,
+		'max_entries': max_entries,
+	}
+	if api_patterns is not None:
+		kwargs['api_patterns'] = api_patterns
+
+	watchdog = NetworkWatchdog(**kwargs)
+	watchdog.attach_to_session()
+	return watchdog
+
+
+def network_prompt_section(watchdog: NetworkWatchdog, last_n: int = 15) -> str:
+	"""Get a formatted prompt section from the watchdog's captured entries.
+
+	Returns an empty string if no API calls have been captured yet.
+	"""
+	return watchdog.format_for_prompt(last_n=last_n)

--- a/scripts/qa/qa_full.py
+++ b/scripts/qa/qa_full.py
@@ -17,16 +17,19 @@ from browser_use import Agent
 
 # Configure loguru
 logger.remove()
-logger.add(sys.stderr, format="<green>{time:HH:mm:ss}</green> | <level>{level: <8}</level> | <cyan>{message}</cyan>", level="INFO")
-logger.add("qa_reports/qa_full_{time:YYYY-MM-DD}.log", rotation="10 MB", level="DEBUG")
+logger.add(
+	sys.stderr, format='<green>{time:HH:mm:ss}</green> | <level>{level: <8}</level> | <cyan>{message}</cyan>', level='INFO'
+)
+logger.add('qa_reports/qa_full_{time:YYYY-MM-DD}.log', rotation='10 MB', level='DEBUG')
 
 from shared import (
-	DEV_URL,
+	attach_network_watchdog,
 	cleanup_temp_profiles,
 	create_browser_session,
 	create_llm,
 	get_github_issues,
 	human_takeover_prompt,
+	network_prompt_section,
 	save_report,
 	sitemap_prompt_section,
 )
@@ -35,9 +38,9 @@ from shared import (
 async def fetch_sitemap_async() -> dict:
 	"""Fetch sitemap with fallback."""
 	from shared import fetch_sitemap
+
 	sitemap = await fetch_sitemap()
 	if not sitemap:
-		from shared import get_sitemap_or_fallback
 		logger.warning('Using hardcoded sitemap fallback')
 		return {
 			'public': [
@@ -52,9 +55,21 @@ async def fetch_sitemap_async() -> dict:
 			'admin': {
 				'path': '/admin',
 				'tabs': [
-					'Site Settings', 'Users', 'Leads', 'Blogs', 'Testimonials', 'Images',
-					'Find & Replace', 'Dev Manual', 'Webhook / CRM', 'AI Content',
-					'AI Settings', 'Business Info', 'Branding', 'Content', 'Email Settings',
+					'Site Settings',
+					'Users',
+					'Leads',
+					'Blogs',
+					'Testimonials',
+					'Images',
+					'Find & Replace',
+					'Dev Manual',
+					'Webhook / CRM',
+					'AI Content',
+					'AI Settings',
+					'Business Info',
+					'Branding',
+					'Content',
+					'Email Settings',
 				],
 			},
 			'restricted': ['/dev-admin'],
@@ -69,6 +84,9 @@ async def main():
 
 	llm = create_llm('sonnet')
 	session, tmp_dir = create_browser_session()
+
+	# Attach network interception — captures API calls for agent visibility
+	network_watchdog = attach_network_watchdog(session)
 
 	# Build admin tabs list for targeted testing
 	admin_tabs = sitemap.get('admin', {}).get('tabs', [])
@@ -139,6 +157,15 @@ For EACH tab: click it, scroll through all content, try every button, fill every
 - Change a color, save, check public site — did it update?
 - REVERT the color back
 
+## NETWORK MONITORING (ACTIVE)
+Network interception is enabled. You can see API calls, status codes, and response headers
+in the system context. Pay attention to:
+- 4xx/5xx errors on API calls — these indicate server-side problems
+- `x-data-source` headers — shows if data comes from DB, cache, or JSON
+- `x-cache` headers — shows if responses are cached
+- Failed requests — network errors that don't surface in the UI
+Report any API errors you observe in the "NETWORK ISSUES" section of your report.
+
 ## RULES
 - DO NOT visit /dev-admin
 - Prefix test data with "E2E-BROWSERUSE-TEST"
@@ -153,10 +180,14 @@ For EACH tab: click it, scroll through all content, try every button, fill every
 ### NEW ISSUES
 ### DATA SOURCES OBSERVED (data-source attributes found)
 ### HUMAN INTERACTIONS OBSERVED (if any)
+### NETWORK ISSUES (API errors, failed requests, unexpected status codes)
 ### OVERALL SCORE (/10)
 """
 
 	logger.info(f'Starting QA with {len(untested_tabs)} untested admin tabs...')
+
+	# Build network context that will be appended to the system message
+	network_context = network_prompt_section(network_watchdog, last_n=15)
 
 	agent = Agent(
 		task=task,
@@ -166,6 +197,7 @@ For EACH tab: click it, scroll through all content, try every button, fill every
 		max_actions_per_step=3,
 		llm_timeout=180,
 		step_timeout=240,
+		extend_system_message=network_context if network_context else None,
 	)
 
 	result = await agent.run(max_steps=40)

--- a/scripts/qa/shared.py
+++ b/scripts/qa/shared.py
@@ -19,6 +19,7 @@ import httpx
 from loguru import logger
 
 from browser_use import BrowserProfile, BrowserSession
+from browser_use.browser.watchdogs.network_watchdog import NetworkWatchdog
 from browser_use.llm.claude_code.chat import ChatClaudeCode
 
 # Base URL for the dev site
@@ -36,7 +37,9 @@ async def fetch_sitemap() -> dict | None:
 			resp = await client.get(f'{DEV_URL}/api/dev/sitemap')
 			if resp.status_code == 200:
 				data = resp.json()
-				logger.success(f"Fetched sitemap: {len(data.get('public', []))} public, {len(data.get('admin', {}).get('tabs', []))} admin tabs")
+				logger.success(
+					f'Fetched sitemap: {len(data.get("public", []))} public, {len(data.get("admin", {}).get("tabs", []))} admin tabs'
+				)
 				return data
 			else:
 				logger.warning(f'Sitemap returned {resp.status_code} — using hardcoded fallback')
@@ -67,9 +70,21 @@ def get_sitemap_or_fallback() -> dict:
 		'admin': {
 			'path': '/admin',
 			'tabs': [
-				'Site Settings', 'Users', 'Leads', 'Blogs', 'Testimonials', 'Images',
-				'Find & Replace', 'Dev Manual', 'Webhook / CRM', 'AI Content',
-				'AI Settings', 'Business Info', 'Branding', 'Content', 'Email Settings',
+				'Site Settings',
+				'Users',
+				'Leads',
+				'Blogs',
+				'Testimonials',
+				'Images',
+				'Find & Replace',
+				'Dev Manual',
+				'Webhook / CRM',
+				'AI Content',
+				'AI Settings',
+				'Business Info',
+				'Branding',
+				'Content',
+				'Email Settings',
 			],
 		},
 		'restricted': ['/dev-admin'],
@@ -94,8 +109,8 @@ def get_github_issues(repo: str = 'Mark0025/wes') -> str:
 	issues = json.loads(result.stdout)
 	lines = []
 	for issue in issues:
-		labels = ', '.join(l['name'] for l in issue.get('labels', []))
-		lines.append(f"- #{issue['number']}: {issue['title']} [{labels}]")
+		labels = ', '.join(label['name'] for label in issue.get('labels', []))
+		lines.append(f'- #{issue["number"]}: {issue["title"]} [{labels}]')
 	logger.success(f'Fetched {len(lines)} open issues')
 	return '\n'.join(lines)
 
@@ -141,7 +156,7 @@ def sitemap_prompt_section(sitemap: dict) -> str:
 	lines.append('')
 	lines.append('### Public Pages')
 	for page in sitemap.get('public', []):
-		lines.append(f"- `{DEV_URL}{page['path']}` — {page['name']}")
+		lines.append(f'- `{DEV_URL}{page["path"]}` — {page["name"]}')
 	lines.append('')
 	lines.append(f'### Admin Dashboard ({DEV_URL}/admin)')
 	lines.append('Tabs in sidebar: ' + ', '.join(sitemap.get('admin', {}).get('tabs', [])))
@@ -198,7 +213,7 @@ def create_test_image(path: str = '/tmp/browser-use-test-image.png') -> str:
 
 	def chunk(chunk_type: bytes, data: bytes) -> bytes:
 		c = chunk_type + data
-		crc = struct.pack('>I', _zlib.crc32(c) & 0xffffffff)
+		crc = struct.pack('>I', _zlib.crc32(c) & 0xFFFFFFFF)
 		return struct.pack('>I', len(data)) + c + crc
 
 	png = b'\x89PNG\r\n\x1a\n'
@@ -211,9 +226,44 @@ def create_test_image(path: str = '/tmp/browser-use-test-image.png') -> str:
 	return path
 
 
+def attach_network_watchdog(
+	session: BrowserSession,
+	max_entries: int = 100,
+	api_patterns: list[str] | None = None,
+) -> NetworkWatchdog:
+	"""Attach a NetworkWatchdog to a BrowserSession.
+
+	Call this BEFORE the session connects to the browser. The watchdog
+	will automatically start capturing API calls once the browser connects.
+
+	Returns the watchdog instance — use ``watchdog.format_for_prompt()``
+	to get a formatted string for agent context injection.
+	"""
+	NetworkWatchdog.model_rebuild()
+
+	kwargs: dict = {
+		'event_bus': session.event_bus,
+		'browser_session': session,
+		'max_entries': max_entries,
+	}
+	if api_patterns is not None:
+		kwargs['api_patterns'] = api_patterns
+
+	watchdog = NetworkWatchdog(**kwargs)
+	watchdog.attach_to_session()
+	logger.info('🌐 Network watchdog attached — will capture API calls')
+	return watchdog
+
+
+def network_prompt_section(watchdog: NetworkWatchdog, last_n: int = 15) -> str:
+	"""Format captured network activity as a prompt section for the agent."""
+	return watchdog.format_for_prompt(last_n=last_n)
+
+
 def cleanup_temp_profiles():
 	"""Remove all temporary Chrome profiles."""
 	import glob
+
 	for d in glob.glob('/tmp/browser-use-chrome-*'):
 		shutil.rmtree(d, ignore_errors=True)
 	logger.info('Cleaned up temp Chrome profiles')

--- a/tests/ci/browser/test_network_watchdog.py
+++ b/tests/ci/browser/test_network_watchdog.py
@@ -1,0 +1,309 @@
+"""
+Tests for NetworkWatchdog — verifies that API network interception captures
+requests/responses and formats them correctly for agent context injection.
+
+Uses pytest-httpserver to create a local test server with API endpoints.
+"""
+
+import asyncio
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+from browser_use.browser.profile import BrowserProfile
+from browser_use.browser.session import BrowserSession
+from browser_use.browser.watchdogs.network_watchdog import (
+	NetworkEntry,
+	NetworkWatchdog,
+	_is_api_request,
+)
+
+
+class TestNetworkEntryFormat:
+	"""Test NetworkEntry formatting without browser."""
+
+	def test_format_short_basic(self):
+		entry = NetworkEntry(
+			request_id='r1',
+			url='https://example.com/api/health',
+			method='GET',
+			resource_type='Fetch',
+		)
+		entry.status = 200
+		result = entry.format_short()
+		assert '- GET /api/health' in result
+		assert '200' in result
+
+	def test_format_short_with_headers(self):
+		entry = NetworkEntry(
+			request_id='r2',
+			url='https://example.com/api/blogs',
+			method='POST',
+			resource_type='XHR',
+		)
+		entry.status = 200
+		entry.response_headers = {
+			'x-data-source': 'db:blogs',
+			'x-cache': 'miss',
+			'content-type': 'application/json',
+		}
+		result = entry.format_short()
+		assert 'POST /api/blogs' in result
+		assert '200' in result
+		assert 'x-data-source: db:blogs' in result
+		assert 'x-cache: miss' in result
+
+	def test_format_short_error(self):
+		entry = NetworkEntry(
+			request_id='r3',
+			url='https://example.com/api/missing',
+			method='GET',
+			resource_type='Fetch',
+		)
+		entry.status = 404
+		result = entry.format_short()
+		assert '404' in result
+
+	def test_format_short_failed(self):
+		entry = NetworkEntry(
+			request_id='r4',
+			url='https://example.com/api/timeout',
+			method='GET',
+			resource_type='Fetch',
+		)
+		entry.failed = True
+		entry.error_text = 'net::ERR_CONNECTION_TIMED_OUT'
+		result = entry.format_short()
+		assert 'FAILED' in result
+		assert 'net::ERR_CONNECTION_TIMED_OUT' in result
+
+	def test_format_short_with_query(self):
+		entry = NetworkEntry(
+			request_id='r5',
+			url='https://example.com/api/search?q=test&page=1',
+			method='GET',
+			resource_type='Fetch',
+		)
+		entry.status = 200
+		result = entry.format_short()
+		assert '/api/search?' in result
+
+
+class TestIsApiRequest:
+	"""Test the _is_api_request filter function."""
+
+	def test_xhr_is_api(self):
+		assert _is_api_request('https://example.com/anything', 'XHR', ['/api/'])
+
+	def test_fetch_is_api(self):
+		assert _is_api_request('https://example.com/anything', 'Fetch', ['/api/'])
+
+	def test_api_url_pattern(self):
+		assert _is_api_request('https://example.com/api/users', 'Document', ['/api/'])
+
+	def test_actions_url_pattern(self):
+		assert _is_api_request('https://example.com/actions.ts', None, ['/actions'])
+
+	def test_stylesheet_skipped(self):
+		assert not _is_api_request('https://example.com/api/styles.css', 'Stylesheet', ['/api/'])
+
+	def test_image_skipped(self):
+		assert not _is_api_request('https://example.com/api/logo.png', 'Image', ['/api/'])
+
+	def test_font_skipped(self):
+		assert not _is_api_request('https://example.com/fonts/arial.woff2', 'Font', ['/api/'])
+
+	def test_no_match(self):
+		assert not _is_api_request('https://example.com/page.html', 'Document', ['/api/'])
+
+
+class TestNetworkWatchdogFormatting:
+	"""Test NetworkWatchdog formatting without browser."""
+
+	@pytest.fixture
+	def watchdog_with_entries(self):
+		"""Create a mock watchdog scenario by directly populating entries."""
+		profile = BrowserProfile(headless=True, user_data_dir=None, keep_alive=False)
+		session = BrowserSession(browser_profile=profile)
+		NetworkWatchdog.model_rebuild()
+		watchdog = NetworkWatchdog(
+			event_bus=session.event_bus,
+			browser_session=session,
+			max_entries=50,
+		)
+
+		# Manually add entries to test formatting
+		entries_data = [
+			('r1', 'https://dev.example.com/api/health', 'GET', 200, {}),
+			('r2', 'https://dev.example.com/api/blogs', 'POST', 200, {'x-data-source': 'db:blogs'}),
+			('r3', 'https://dev.example.com/api/preview-image/abc', 'GET', 404, {}),
+			('r4', 'https://dev.example.com/api/settings', 'PUT', 500, {}),
+		]
+
+		for rid, url, method, status, headers in entries_data:
+			entry = NetworkEntry(request_id=rid, url=url, method=method, resource_type='Fetch')
+			entry.status = status
+			entry.response_headers = headers
+			watchdog._entries[rid] = entry
+			watchdog._log.append(entry)
+
+		return watchdog
+
+	def test_format_for_prompt(self, watchdog_with_entries):
+		result = watchdog_with_entries.format_for_prompt(last_n=10)
+		assert '## Network Activity' in result
+		assert 'GET /api/health' in result
+		assert 'POST /api/blogs' in result
+		assert '404' in result
+		assert '500' in result
+		assert 'ERROR' in result
+		assert 'x-data-source: db:blogs' in result
+
+	def test_format_for_prompt_empty(self):
+		profile = BrowserProfile(headless=True, user_data_dir=None, keep_alive=False)
+		session = BrowserSession(browser_profile=profile)
+		NetworkWatchdog.model_rebuild()
+		watchdog = NetworkWatchdog(
+			event_bus=session.event_bus,
+			browser_session=session,
+		)
+		result = watchdog.format_for_prompt()
+		assert result == ''
+
+	def test_get_error_entries(self, watchdog_with_entries):
+		errors = watchdog_with_entries.get_error_entries()
+		assert len(errors) == 2  # 404 and 500
+		statuses = {e.status for e in errors}
+		assert 404 in statuses
+		assert 500 in statuses
+
+	def test_get_entries_last_n(self, watchdog_with_entries):
+		entries = watchdog_with_entries.get_entries(last_n=2)
+		assert len(entries) == 2
+		# Should be the last two entries
+		assert entries[0].url == 'https://dev.example.com/api/preview-image/abc'
+		assert entries[1].url == 'https://dev.example.com/api/settings'
+
+	def test_clear(self, watchdog_with_entries):
+		assert len(watchdog_with_entries._log) > 0
+		watchdog_with_entries.clear()
+		assert len(watchdog_with_entries._log) == 0
+		assert len(watchdog_with_entries._entries) == 0
+
+	def test_error_summary_in_prompt(self, watchdog_with_entries):
+		result = watchdog_with_entries.format_for_prompt()
+		assert '2 API error(s) detected' in result
+
+
+class TestNetworkWatchdogLive:
+	"""Integration tests — verify watchdog captures real browser network traffic."""
+
+	@pytest.fixture
+	async def session_with_watchdog(self):
+		profile = BrowserProfile(headless=True, user_data_dir=None, keep_alive=False)
+		session = BrowserSession(browser_profile=profile)
+		NetworkWatchdog.model_rebuild()
+		watchdog = NetworkWatchdog(
+			event_bus=session.event_bus,
+			browser_session=session,
+			max_entries=50,
+		)
+		watchdog.attach_to_session()
+		await session.start()
+		yield session, watchdog
+		await session.kill()
+
+	async def _wait_for_entries(self, watchdog: NetworkWatchdog, url_fragment: str, timeout: float = 5.0) -> list[NetworkEntry]:
+		"""Poll for entries matching a URL fragment, with timeout."""
+		deadline = asyncio.get_event_loop().time() + timeout
+		while asyncio.get_event_loop().time() < deadline:
+			entries = [e for e in watchdog.get_entries() if url_fragment in e.url]
+			if entries:
+				return entries
+			await asyncio.sleep(0.2)
+		return []
+
+	async def test_captures_api_call(self, httpserver: HTTPServer, session_with_watchdog):
+		session, watchdog = session_with_watchdog
+
+		# Set up test API endpoint
+		httpserver.expect_request('/api/test-endpoint').respond_with_json(
+			{'status': 'ok', 'data': [1, 2, 3]},
+			status=200,
+			headers={'X-Data-Source': 'db:test'},
+		)
+
+		# Create a page that makes a fetch call to our test API
+		page_html = f"""
+		<html><body>
+		<h1>Network Test</h1>
+		<script>
+			fetch('{httpserver.url_for('/api/test-endpoint')}')
+				.then(r => r.json())
+				.then(d => document.title = 'DONE');
+		</script>
+		</body></html>
+		"""
+		httpserver.expect_request('/test-page').respond_with_data(page_html, content_type='text/html')
+
+		from browser_use.browser.events import NavigateToUrlEvent
+
+		await session.event_bus.dispatch(NavigateToUrlEvent(url=httpserver.url_for('/test-page')))
+
+		# Wait for the API call to be captured
+		api_entries = await self._wait_for_entries(watchdog, '/api/test-endpoint', timeout=8.0)
+		assert len(api_entries) >= 1, f'Expected to capture /api/test-endpoint, got: {[e.url for e in watchdog.get_entries()]}'
+		assert api_entries[0].method == 'GET'
+		# Status may or may not be populated depending on CDP event timing
+		# The key assertion is that the request was captured
+
+	async def test_captures_error_response(self, httpserver: HTTPServer, session_with_watchdog):
+		session, watchdog = session_with_watchdog
+
+		# Set up a failing API endpoint
+		httpserver.expect_request('/api/broken').respond_with_json({'error': 'not found'}, status=404)
+
+		page_html = f"""
+		<html><body>
+		<h1>Error Test</h1>
+		<script>
+			fetch('{httpserver.url_for('/api/broken')}')
+				.then(r => document.title = 'DONE');
+		</script>
+		</body></html>
+		"""
+		httpserver.expect_request('/error-page').respond_with_data(page_html, content_type='text/html')
+
+		from browser_use.browser.events import NavigateToUrlEvent
+
+		await session.event_bus.dispatch(NavigateToUrlEvent(url=httpserver.url_for('/error-page')))
+
+		# Wait for the API call to be captured
+		api_entries = await self._wait_for_entries(watchdog, '/api/broken', timeout=8.0)
+		assert len(api_entries) >= 1, f'Expected to capture /api/broken, got: {[e.url for e in watchdog.get_entries()]}'
+
+	async def test_format_for_prompt_after_capture(self, httpserver: HTTPServer, session_with_watchdog):
+		session, watchdog = session_with_watchdog
+
+		httpserver.expect_request('/api/data').respond_with_json({'items': []}, status=200)
+
+		page_html = f"""
+		<html><body>
+		<script>
+			fetch('{httpserver.url_for('/api/data')}')
+				.then(r => document.title = 'DONE');
+		</script>
+		</body></html>
+		"""
+		httpserver.expect_request('/format-test').respond_with_data(page_html, content_type='text/html')
+
+		from browser_use.browser.events import NavigateToUrlEvent
+
+		await session.event_bus.dispatch(NavigateToUrlEvent(url=httpserver.url_for('/format-test')))
+
+		# Wait for capture
+		await self._wait_for_entries(watchdog, '/api/data', timeout=8.0)
+
+		prompt = watchdog.format_for_prompt()
+		assert '## Network Activity' in prompt
+		assert '/api/data' in prompt


### PR DESCRIPTION
## Summary
- Adds `NetworkWatchdog` that captures API/XHR network traffic via CDP Network domain
- Filters to only API-relevant requests (skips images, fonts, stylesheets)
- Exposes a rolling log with `format_for_prompt()` for agent context injection
- Integrates with QA system: `attach_network_watchdog()` + `network_prompt_section()` helpers
- Updated `qa_full.py` to inject network activity into agent context via `extend_system_message`

The agent can now see:
- Which API calls the frontend makes (method + path)
- HTTP status codes (4xx/5xx errors highlighted)
- Response headers like `x-data-source`, `x-cache`, `content-type`
- Failed requests that don't surface in the UI

## Test plan
- [x] 19 unit tests for `NetworkEntry` formatting, `_is_api_request` filtering, and `NetworkWatchdog` log/prompt methods
- [x] 3 live browser integration tests verifying real CDP capture of API calls, error responses, and prompt formatting
- [x] All 22 tests passing
- [x] ruff check + ruff format + pyright clean
- [ ] Manual QA run with `qa_full.py` to verify network context injection (requires dev site access)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Network Interception Feature

**Overview**: Adds `NetworkWatchdog` to capture API/XHR network traffic via Chrome DevTools Protocol, exposing recent requests/responses with HTTP status, headers, and failure information to the agent context. Addresses issue #3 by enabling agents to detect server errors (4xx/5xx), verify data provenance (cache vs. DB), and surface broken endpoints.

### Implementation Quality Assessment

**Architecture & Design** ✅
- Properly extends `BaseWatchdog` following established patterns
- Uses Pydantic v2 correctly (`ConfigDict`, `Field`, `PrivateAttr`)
- Event-driven via CDP `RequestWillBeSentEvent`, `ResponseReceivedEvent`, `LoadingFailedEvent`
- Bounded FIFO queue (deque) prevents memory bloat
- Smart filtering (`_is_api_request`) skips static assets (images, fonts, CSS) and non-matching URLs

**Test Coverage** ✅
- 22 comprehensive tests: 5 unit tests for `NetworkEntry` formatting, 8 for `_is_api_request` filtering logic, 6 for watchdog methods (formatting, entry retrieval, clearing), 3 live integration tests with real HTTP server
- All passing with pytest-httpserver
- Validates CDP capture, error responses, prompt formatting

**Code Quality Issues** ⚠️
- **Deque Initialization Redundancy**: `_log` is initialized in `PrivateAttr` factory with hardcoded `maxlen=100`, then immediately overridden in `__init__` with `maxlen=self.max_entries`. While functional, this is confusing and should be consolidated into `__init__` only.
- **Exception Swallowing**: All 7 event handlers use bare `except Exception: pass`, silently discarding errors. Prevents debugging of CDP failures. Should at least log at debug level with context.
- **Module Duplication**: Functions `attach_network_watchdog()` and `network_prompt_section()` are identically defined in both `scripts/qa/network_interception.py` (63 LOC) and `scripts/qa/shared.py` (58 LOC). This violates DRY; one file should be removed or `network_interception.py` should be a thin re-export.
- **Missing Export**: `NetworkWatchdog` class not exported in `browser_use/browser/watchdogs/__init__.py` (file is empty). Should be added for consistency.
- **Response Header Normalization**: Handles multiple header formats (dict, list, iterable) with fallback error handling — robust but adds complexity. Could be simplified with stricter type assumptions.

**Integration** ✅
- Cleanly integrated into `qa_full.py` — network context injected into agent system message via `extend_system_message`
- QA prompt enhanced with "NETWORK MONITORING (ACTIVE)" section and "NETWORK ISSUES" report subsection
- Calls `model_rebuild()` before instantiation (Pydantic requirement for forward references)

**API Design** ✅
- Public methods: `get_entries()`, `get_error_entries()`, `format_for_prompt()`, `clear()`
- Configurable `max_entries` (default 100) and `api_patterns` (default includes `/api/`, `/actions`, `/graphql`, `/trpc/`, `/_next/data/`)
- `format_short()` on `NetworkEntry` produces clean one-liners highlighting 4xx/5xx errors and key headers (`x-data-source`, `x-cache`, `content-type`)

### Breaking Changes
None — purely additive feature.

### Recommendations for Production
1. **Remove duplication**: Delete `scripts/qa/network_interception.py` and keep only `shared.py`, or make one a thin wrapper.
2. **Fix deque init**: Remove hardcoded `maxlen=100` from `PrivateAttr` factory; only override in `__init__`.
3. **Add debug logging**: Replace silent exception handlers with `self.logger.debug(f'Network handler failed: {e}')` for troubleshooting.
4. **Export NetworkWatchdog**: Add to `browser_use/browser/watchdogs/__init__.py` for consistency with other watchdogs.
5. **Simplify header parsing**: Assume CDP always provides headers in consistent format; fail loudly if format is unexpected rather than silently defaulting to empty dict.

### CI Status
- All tests passing
- Ruff checks/formatting clean
- Pyright type-checking clean
- Manual QA with `qa_full.py` pending (requires dev site access)

### Closes
Issue #3 (agent visibility into API calls, HTTP status codes, response headers, server errors)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->